### PR TITLE
default std_error: highest lvl with >= 32 bins

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -146,11 +146,8 @@ end
 # Take the highest lvl with at least 32 bins.
 # (Chose 32 based on https://doi.org/10.1119/1.3247985)
 function _select_lvl_for_std_error(B::LogBinner{N,T})::Int64 where {N, T}
-    n = B.count[1]
-    n == 0 && (return 0)
-    max_bs = n / 32
-
-     i = findlast(bs -> bs <= max_bs, 2 .^ (0:N))
+    B.count[1] == 0 && (return 0) # return 0 if no values have been pushed
+    i = findlast(x -> x >= 32, B.count)
     isnothing(i) ? 1 : i
 end
 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -141,15 +141,34 @@ end
 ################################################################################
 
 
+# Heuristic for selecting the level with the (presumably) most reliable
+# standard error estimate:
+# Take the highest lvl with at least 32 bins.
+# (Chose 32 based on https://doi.org/10.1119/1.3247985)
+function _select_lvl_for_std_error(B::LogBinner{N,T})::Int64 where {N, T}
+    n = B.count[1]
+    n == 0 && (return 0)
+    max_bs = n / 32
+
+     i = findlast(bs -> bs <= max_bs, 2 .^ (0:N))
+    isnothing(i) ? 1 : i
+end
+
+ """
+    std_error(BinningAnalysis[, lvl=0])
+
+Calculates the standard error for a given level.
+"""
+function std_error(B::LogBinner{N, T}, lvl::Int64=_select_lvl_for_std_error(B)) where {N, T <: Number}
+    sqrt(varN(B, lvl))
+end
+
 """
     std_error(BinningAnalysis[, lvl=0])
 
 Calculates the standard error for a given level.
 """
-function std_error(B::LogBinner{N, T}, lvl::Int64=0) where {N, T <: Number}
-    sqrt(varN(B, lvl))
-end
-function std_error(B::LogBinner{N, T}, lvl::Int64=0) where {N, T <: AbstractArray}
+function std_error(B::LogBinner{N, T}, lvl::Int64=_select_lvl_for_std_error(B)) where {N, T <: AbstractArray}
     sqrt.(varN(B, lvl))
 end
 


### PR DESCRIPTION
As per discussion with @ffreyer, we set this (arguably crude) default.

The number 32 is based on https://doi.org/10.1119/1.3247985 and [Gubernatis, Kawashima, Werner (2016)](https://www.amazon.de/Quantum-Monte-Carlo-Methods-Algorithms/dp/1107006422).

We can improve on this in the future by writing supplementing it with a plateau finder of some sort.