### PR TITLE
Overloading some basic Base functions

### DIFF
--- a/src/BinningAnalysis.jl
+++ b/src/BinningAnalysis.jl
@@ -1,10 +1,11 @@
 module BinningAnalysis
 
 import Statistics: mean, var
-import Base: push!, append!, show, summary, eltype, isempty, length, ndims
+import Base: push!, append!, show, summary, eltype,
+            isempty, length, ndims, empty!
 
 include("binning.jl")
-export LogBinner, push!, append!
+export LogBinner
 
 include("statistics.jl")
 export mean, var, varN, tau, std_error

--- a/src/BinningAnalysis.jl
+++ b/src/BinningAnalysis.jl
@@ -1,7 +1,7 @@
 module BinningAnalysis
 
 import Statistics: mean, var
-import Base: push!, append!, show, summary
+import Base: push!, append!, show, summary, eltype, isempty, length, ndims
 
 include("binning.jl")
 export LogBinner, push!, append!

--- a/src/binning.jl
+++ b/src/binning.jl
@@ -20,6 +20,16 @@ struct LogBinner{N, T}
     count::Vector{Int64}
 end
 
+
+
+# Overload some basic Base functions
+Base.eltype(B::LogBinner{N,T}) where {N,T} = T
+Base.isempty(B::LogBinner) = B.count[1] == 0
+Base.length(B::LogBinner) = B.count[1]
+Base.ndims(B::LogBinner{N,T}) where {N,T} = ndims(eltype(B))
+
+
+
 """
     LogBinner([T = Float64, N = 32])
 

--- a/src/binning.jl
+++ b/src/binning.jl
@@ -26,7 +26,8 @@ end
 Base.eltype(B::LogBinner{N,T}) where {N,T} = T
 Base.length(B::LogBinner) = B.count[1]
 Base.ndims(B::LogBinner{N,T}) where {N,T} = ndims(eltype(B))
-Base.isempty(B::LogBinner) = B.count[1] == 0
+Base.isempty(B::LogBinner) = length(B) == 0
+
 
 
 """
@@ -48,8 +49,8 @@ function Base.empty!(B::LogBinner)
             B.x2_sum[i] = z
         else 
             # arrays
-            fill!(B.x_sum, z)
-            fill!(B.x2_sum, z)
+            fill!(B.x_sum[i], z)
+            fill!(B.x2_sum[i], z)
         end
     end
 

--- a/src/binning.jl
+++ b/src/binning.jl
@@ -24,9 +24,50 @@ end
 
 # Overload some basic Base functions
 Base.eltype(B::LogBinner{N,T}) where {N,T} = T
-Base.isempty(B::LogBinner) = B.count[1] == 0
 Base.length(B::LogBinner) = B.count[1]
 Base.ndims(B::LogBinner{N,T}) where {N,T} = ndims(eltype(B))
+Base.isempty(B::LogBinner) = B.count[1] == 0
+
+
+"""
+    empty!(B::LogBinner)
+
+Clear the binner, i.e. reset it to its inital state.
+"""
+function Base.empty!(B::LogBinner)
+    !isempty(B) || return
+
+    # get zero
+    z = zero(eltype(eltype(B)))
+
+    # reset x_sum and x2_sum to all zeros
+    @inbounds for i in eachindex(B.x_sum)
+        if ndims(B) == 0 # compile time
+            # numbers
+            B.x_sum[i] = z
+            B.x2_sum[i] = z
+        else 
+            # arrays
+            fill!(B.x_sum, z)
+            fill!(B.x2_sum, z)
+        end
+    end
+
+    # reset counts
+    fill!(B.count, 0)
+
+    # reset compressors
+    for c in B.compressors
+        if ndims(B) == 0 # compile time
+            c.value = z
+        else
+            fill!(c.value, z)
+        end
+        c.switch = false
+    end
+
+    nothing
+end
 
 
 

--- a/src/cosmetics.jl
+++ b/src/cosmetics.jl
@@ -3,7 +3,7 @@ function _println_header(io::IO, B::LogBinner{N,T}) where {N, T}
 end
 
 function _println_body(io::IO, B::LogBinner{N,T}) where {N, T}
-    n = B.count[1]
+    n = length(B)
     print("| Count: ", n)
     if n > 0 && ndims(B) == 0
         print("\n| Mean: ", round.(mean(B), digits=5))

--- a/src/cosmetics.jl
+++ b/src/cosmetics.jl
@@ -5,7 +5,7 @@ end
 function _println_body(io::IO, B::LogBinner{N,T}) where {N, T}
     n = B.count[1]
     print("| Count: ", n)
-    if n > 0
+    if n > 0 && ndims(B) == 0
         print("\n| Mean: ", round.(mean(B), digits=5))
         print("\n| StdError: ", round.(std_error(B), digits=5))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,153 +2,192 @@ using BinningAnalysis
 using Test
 
 
-@testset "Checking converging data (Real)" begin
-    BA = LogBinner()
+@testset "All Tests" begin
+    @testset "Checking converging data (Real)" begin
+        BA = LogBinner()
 
-    # block of maximally correlated values:
-    N_corr = 16
+        # block of maximally correlated values:
+        N_corr = 16
 
-    # number of blocks
-    N_blocks = 131_072 # 2^17
+        # number of blocks
+        N_blocks = 131_072 # 2^17
 
-    for _ in 1:N_blocks
-        x = rand()
-        for __ in 1:N_corr
-            push!(BA, x)
+        for _ in 1:N_blocks
+            x = rand()
+            for __ in 1:N_corr
+                push!(BA, x)
+            end
+        end
+
+        # BA must diverge until 16 values are binned
+        for lvl in 1:4
+            @test !has_converged(BA, lvl)
+        end
+
+        # Afterwards it must converge (for a while)
+        for lvl in 5:8
+            @test has_converged(BA, lvl)
+        end
+        # Later values may fluctuate due to small samples / small threshold in
+        # has_converged
+
+        # means should be consistent
+        means = BinningAnalysis.all_means(BA)
+        for x in means
+            @test x ≈ means[1]
         end
     end
 
-    # BA must diverge until 16 values are binned
-    for lvl in 1:4
-        @test !has_converged(BA, lvl)
+    @testset "Check variance for Complex values" begin
+        # NOTE
+        # Due to the different (mathematically equivalent) versions of the variance
+        # calculated here, the values are onyl approximately the same. (Float error)
+        xs = rand(ComplexF64, 1_000_000)
+        BA = LogBinner(ComplexF64)
+
+        # Test small set (off by one errors are large here)
+        for x in xs[1:10]; push!(BA, x) end
+        @test var(BA, 0) ≈ var(xs[1:10])
+        @test varN(BA, 0) ≈ var(xs[1:10])/10
+
+        # Test full set
+        for x in xs[11:end]; push!(BA, x) end
+        @test var(BA, 0) ≈ var(xs)
+        @test varN(BA, 0) ≈ var(xs)/1_000_000
     end
 
-    # Afterwards it must converge (for a while)
-    for lvl in 5:8
-        @test has_converged(BA, lvl)
-    end
-    # Later values may fluctuate due to small samples / small threshold in
-    # has_converged
-
-    # means should be consistent
-    means = BinningAnalysis.all_means(BA)
-    for x in means
-        @test x ≈ means[1]
-    end
-end
-
-@testset "Check variance for Complex values" begin
-    # NOTE
-    # Due to the different (mathematically equivalent) versions of the variance
-    # calculated here, the values are onyl approximately the same. (Float error)
-    xs = rand(ComplexF64, 1_000_000)
-    BA = LogBinner(ComplexF64)
-
-    # Test small set (off by one errors are large here)
-    for x in xs[1:10]; push!(BA, x) end
-    @test var(BA, 0) ≈ var(xs[1:10])
-    @test varN(BA, 0) ≈ var(xs[1:10])/10
-
-    # Test full set
-    for x in xs[11:end]; push!(BA, x) end
-    @test var(BA, 0) ≈ var(xs)
-    @test varN(BA, 0) ≈ var(xs)/1_000_000
-end
 
 
+    @testset "Checking converging data (Complex)" begin
+        BA = LogBinner(ComplexF64)
 
-@testset "Checking converging data (Complex)" begin
-    BA = LogBinner(ComplexF64)
+        # block of maximally correlated values:
+        N_corr = 16
 
-    # block of maximally correlated values:
-    N_corr = 16
+        # number of blocks
+        N_blocks = 131_072 # 2^17
 
-    # number of blocks
-    N_blocks = 131_072 # 2^17
+        for _ in 1:N_blocks
+            x = rand(ComplexF64)
+            for __ in 1:N_corr
+                push!(BA, x)
+            end
+        end
 
-    for _ in 1:N_blocks
-        x = rand(ComplexF64)
-        for __ in 1:N_corr
-            push!(BA, x)
+        # BA must diverge until 16 values are binned
+        for lvl in 1:4
+            @test !has_converged(BA, lvl)
+        end
+
+        # Afterwards it must converge (for a while)
+        for lvl in 5:8
+            @test has_converged(BA, lvl)
+        end
+        # Later values may fluctuate due to small samples / small threshold in
+        # has_converged
+
+        # means should be consistent
+        means = BinningAnalysis.all_means(BA)
+        for x in means
+            @test x ≈ means[1]
         end
     end
 
-    # BA must diverge until 16 values are binned
-    for lvl in 1:4
-        @test !has_converged(BA, lvl)
-    end
-
-    # Afterwards it must converge (for a while)
-    for lvl in 5:8
-        @test has_converged(BA, lvl)
-    end
-    # Later values may fluctuate due to small samples / small threshold in
-    # has_converged
-
-    # means should be consistent
-    means = BinningAnalysis.all_means(BA)
-    for x in means
-        @test x ≈ means[1]
-    end
-end
 
 
+    @testset "Checking converging data (Vector)" begin
+        BA = LogBinner(zeros(3))
 
-@testset "Checking converging data (Vector)" begin
-    BA = LogBinner(zeros(3))
+        # block of maximally correlated values:
+        N_corr = 16
 
-    # block of maximally correlated values:
-    N_corr = 16
+        # number of blocks
+        N_blocks = 131_072 # 2^17
 
-    # number of blocks
-    N_blocks = 131_072 # 2^17
+        for _ in 1:N_blocks
+            x = rand(Float64, 3)
+            for __ in 1:N_corr
+                push!(BA, x)
+            end
+        end
 
-    for _ in 1:N_blocks
-        x = rand(Float64, 3)
-        for __ in 1:N_corr
-            push!(BA, x)
+        # BA must diverge until 16 values are binned
+        for lvl in 1:4
+            @test !has_converged(BA, lvl)
+        end
+
+        # Afterwards it must converge (for a while)
+        for lvl in 5:8
+            @test has_converged(BA, lvl)
+        end
+        # Later values may fluctuate due to small samples / small threshold in
+        # has_converged
+
+        # means should be consistent
+        means = BinningAnalysis.all_means(BA)
+        for i in eachindex(means)
+            @test means[i] ≈ means[1]
         end
     end
 
-    # BA must diverge until 16 values are binned
-    for lvl in 1:4
-        @test !has_converged(BA, lvl)
+
+
+    @testset "Type promotion" begin
+        Bf = LogBinner(zero(1.)) # Float64 LogBinner
+        Bc = LogBinner(zero(im)) # Float64 LogBinner
+
+        # Check that this doesn't throw (TODO: is there a better way?)
+        @test (append!(Bf, rand(1:10, 10000)); true)
+        @test (append!(Bc, rand(10000)); true)
     end
 
-    # Afterwards it must converge (for a while)
-    for lvl in 5:8
-        @test has_converged(BA, lvl)
+
+    @testset "Sum-type heuristic" begin
+        # numbers
+        @test typeof(LogBinner(zero(Int64))) == LogBinner{32,Float64}
+        @test typeof(LogBinner(zero(ComplexF16))) == LogBinner{32,ComplexF64}
+
+        # arrays
+        @test typeof(LogBinner(zeros(Int64, 2,2))) == LogBinner{32,Matrix{Float64}}
+        @test typeof(LogBinner(zeros(ComplexF16, 2,2))) == LogBinner{32,Matrix{ComplexF64}}
     end
-    # Later values may fluctuate due to small samples / small threshold in
-    # has_converged
 
-    # means should be consistent
-    means = BinningAnalysis.all_means(BA)
-    for i in eachindex(means)
-        @test means[i] ≈ means[1]
+
+    @testset "Basic Base functions" begin
+        # numbers
+        for T in (Float64, ComplexF64)
+            B = LogBinner(T)
+
+            @test length(B) == 0
+            @test ndims(B) == 0
+            @test isempty(B)
+            @test eltype(B) == T
+
+            append!(B, rand(1000))
+            @test length(B) == 1000
+            @test !isempty(B)
+
+            empty!(B)
+            @test length(B) == 0
+            @test isempty(B)
+        end
+
+        # arrays
+        for T in (Float64, ComplexF64)
+            B = LogBinner(zeros(T, 2, 3))
+
+            @test length(B) == 0
+            @test ndims(B) == 2
+            @test isempty(B)
+            @test eltype(B) == Array{T, 2}
+
+            append!(B, [rand(T, 2,3) for _ in 1:1000])
+            @test length(B) == 1000
+            @test !isempty(B)
+
+            empty!(B)
+            @test length(B) == 0
+            @test isempty(B)
+        end
     end
-end
-
-
-
-@testset "Type promotion" begin
-    Bf = LogBinner(zero(1.)) # Float64 LogBinner
-    Bc = LogBinner(zero(im)) # Float64 LogBinner
-
-    # Check that this doesn't throw (TODO: is there a better way?)
-    @test (append!(Bf, rand(1:10, 10000)); true)
-    @test (append!(Bc, rand(10000)); true)
-end
-
-
-
-
-@testset "Sum-type heuristic" begin
-    # numbers
-    @test typeof(LogBinner(zero(Int64))) == LogBinner{32,Float64}
-    @test typeof(LogBinner(zero(ComplexF16))) == LogBinner{32,ComplexF64}
-
-    # arrays
-    @test typeof(LogBinner(zeros(Int64, 2,2))) == LogBinner{32,Matrix{Float64}}
-    @test typeof(LogBinner(zeros(ComplexF16, 2,2))) == LogBinner{32,Matrix{ComplexF64}}
 end


### PR DESCRIPTION
Overload `eltype`, `length`, `ndims`, `isempty` (#3) for `LogBinner`.

Are these all?

Closes #3, #5