### PR TITLE
`capacity` keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,23 @@ where $N$ is the number of values pushed.
 ```julia
 # Create a new logarithmic binner for `Float64`s.
 B = LogBinner()
-# On default, 2^32-1 values can be added to the binner. This value can be
-# changed by passing an integer to LogBinner, e.g. LogBinner(64) for a capacity
-# of 2^64-1
+# On default, 2^32-1 ≈ 4 billion values can be added to the binner. This value can be
+# tuned with the `capacity` keyword argument.
 
 # Data can be added with push!,
 push!(B, value)
 # or append! (multiple values at once)
 append!(B, [1,2,3])
 
-# Get the mean and standard error of each binning level
-xs  = all_means(B)
+# Get the mean, standard error, and autocorrelation estimates
+x  = mean(B)
+Δx = std_error(B)
+tau_x = tau(B)
+
+# You can also get the standard error estimates for all binning levels individually.
 Δxs = all_std_errors(B)
 
-# Or get them for an individual binning level
-x3  = mean(B, 3)
-Δx3 = std_error(B, 3)
-# Binning level 0 includes the completely unbinned values. It is not included
-# in all_means etc.
-
-# Check whether a level has converged
+# BETA: Check whether a level has converged
 has_converged(B, 3)
 # This checks whether variance/N of level 2 and 3 is approximately the same.
 # To be sure that the binning analysis has converged, this criterion should be
@@ -60,7 +57,4 @@ has_converged(B, 3)
 # Note that this criterion is generally not true close to the maximum binning
 # level. Usually this is the result of the small effective sample size, rather
 # than a convergence failure.
-
-# The autocorrelation time is given by
-τ = tau(B, 3)
 ```

--- a/src/BinningAnalysis.jl
+++ b/src/BinningAnalysis.jl
@@ -5,7 +5,7 @@ import Base: push!, append!, show, summary, eltype,
             isempty, length, ndims, empty!
 
 include("binning.jl")
-export LogBinner
+export LogBinner, capacity
 
 include("statistics.jl")
 export mean, var, varN, tau, std_error

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,55 @@ using Test
 
 
 @testset "All Tests" begin
+    @testset "Constructors and basic properties" begin
+        # numbers
+        for T in (Float64, ComplexF64)
+            B = LogBinner(T)
+
+            @test length(B) == 0
+            @test ndims(B) == 0
+            @test isempty(B)
+            @test eltype(B) == T
+            @test capacity(B) == 2^32 - 1
+            @test BinningAnalysis.nlevels(B) == 32
+
+            append!(B, rand(1000))
+            @test length(B) == 1000
+            @test !isempty(B)
+
+            empty!(B)
+            @test length(B) == 0
+            @test isempty(B)
+        end
+
+        # arrays
+        for T in (Float64, ComplexF64)
+            B = LogBinner(zeros(T, 2, 3))
+
+            @test length(B) == 0
+            @test ndims(B) == 2
+            @test isempty(B)
+            @test eltype(B) == Array{T, 2}
+            @test capacity(B) == 2^32 - 1
+            @test BinningAnalysis.nlevels(B) == 32
+
+            append!(B, [rand(T, 2,3) for _ in 1:1000])
+            @test length(B) == 1000
+            @test !isempty(B)
+            empty!(B)
+            @test length(B) == 0
+            @test isempty(B)
+        end
+
+        # Constructor arguments
+        B = LogBinner(capacity=12345)
+        @test capacity(B) == 16383
+        @test_throws ArgumentError LogBinner(capacity=0)
+        @test_throws ArgumentError LogBinner(capacity=-1)
+    end
+
+
+
     @testset "Checking converging data (Real)" begin
         BA = LogBinner()
 
@@ -151,47 +200,9 @@ using Test
     end
 
 
-    @testset "Basic Base functions" begin
-        # numbers
-        for T in (Float64, ComplexF64)
-            B = LogBinner(T)
-
-            @test length(B) == 0
-            @test ndims(B) == 0
-            @test isempty(B)
-            @test eltype(B) == T
-
-            append!(B, rand(1000))
-            @test length(B) == 1000
-            @test !isempty(B)
-
-            empty!(B)
-            @test length(B) == 0
-            @test isempty(B)
-        end
-
-        # arrays
-        for T in (Float64, ComplexF64)
-            B = LogBinner(zeros(T, 2, 3))
-
-            @test length(B) == 0
-            @test ndims(B) == 2
-            @test isempty(B)
-            @test eltype(B) == Array{T, 2}
-
-            append!(B, [rand(T, 2,3) for _ in 1:1000])
-            @test length(B) == 1000
-            @test !isempty(B)
-            empty!(B)
-            @test length(B) == 0
-            @test isempty(B)
-        end
-    end
-
-
 
     @testset "Indexing Bounds" begin
-        BA = LogBinner(zero(Float64), 1)
+        BA = LogBinner(zero(Float64); capacity=1)
         for func in [:var, :varN, :mean, :tau]
             # check if func(BA, 0) throws BoundsError
             # It should as level 1 is now the initial level


### PR DESCRIPTION
I made the integer argument of the `LogBinner` constructor a keyword argument and changed its meaning (see #13).

Closes #13 