### PR TITLE
LogBinner overflow handling

### DIFF
--- a/src/log/binning.jl
+++ b/src/log/binning.jl
@@ -203,10 +203,12 @@ function LogBinner(
         ))
     end
 
-    _zero = if T <: Number
-        zero(T)
+    if T <: Number
+        _zero = zero(T)
     elseif T <: AbstractArray
-        B.x_sum[1] .- B.x_sum[1]
+        _zero = B.x_sum[1] .- B.x_sum[1]
+    else
+        throw(ErrorException("Failed to generate zero for type $T."))
     end
 
     # Copy everthing up to lvl = N, fill the rest with neutral elements

--- a/src/log/binning.jl
+++ b/src/log/binning.jl
@@ -206,7 +206,7 @@ function LogBinner(
     if T <: Number
         _zero = zero(T)
     elseif T <: AbstractArray
-        _zero = B.x_sum[1] .- B.x_sum[1]
+        _zero = fill!(similiar(B.x_sum[1]), eltype(B.x_sum[1]))
     else
         throw(ErrorException("Failed to generate zero for type $T."))
     end

--- a/src/log/binning.jl
+++ b/src/log/binning.jl
@@ -206,7 +206,7 @@ function LogBinner(
     if T <: Number
         _zero = zero(T)
     elseif T <: AbstractArray
-        _zero = fill!(similiar(B.x_sum[1]), eltype(B.x_sum[1]))
+        _zero = fill!(similar(B.x_sum[1]), zero(eltype(B.x_sum[1])))
     else
         throw(ErrorException("Failed to generate zero for type $T."))
     end

--- a/src/log/binning.jl
+++ b/src/log/binning.jl
@@ -152,9 +152,10 @@ Values can be added using `push!` and `append!`.
 
 Creates a new `LogBinner` and adds all elements from the given timeseries.
 """
-function LogBinner(x::T;
+function LogBinner(
+        x::T;
         capacity::Int64 = _nlvls2capacity(32)
-        ) where {T <: Union{Number, AbstractArray}}
+    ) where {T <: Union{Number, AbstractArray}}
 
     # check keyword args
     capacity <= 0 && throw(ArgumentError("`capacity` must be finite and positive."))
@@ -249,12 +250,12 @@ function _push!(B::LogBinner{N, T}, lvl::Int64, value::S) where {N, T <: Number,
         return nothing
     else
         # Do averaging
+        C.switch = false
         if lvl == N
             # No more propagation possible -> throw error
-            push!(B.overflow, value)
+            push!(B.overflow, 0.5 * (C.value + value))
         else
             # propagate to next lvl
-            C.switch = false
             _push!(B, lvl+1, 0.5 * (C.value + value))
             return nothing
         end
@@ -278,10 +279,10 @@ function _push!(
         C.switch = true
         return nothing
     else
+        C.switch = false
         if lvl == N
-            push!(B.overflow, value)
+            push!(B.overflow, 0.5 * (C.value .+ value))
         else
-            C.switch = false
             _push!(B, lvl+1, 0.5 * (C.value .+ value))
             return nothing
         end

--- a/test/logbinning.jl
+++ b/test/logbinning.jl
@@ -69,10 +69,11 @@
     for T in [Float64, ComplexF32]
         xs = rand(T, 1000)
         small_Binner = LogBinner(T, capacity = 200)
-        large_Binner = LogBinner(T)
+        large_Binner = LogBinner(T, capacity = 2000)
         append!(small_Binner, xs)
         append!(large_Binner, xs)
-        ext_Binner = LogBinner(small_Binner)
+        @test_throws OverflowError LogBinner(small_Binner, capacity = 100)
+        ext_Binner = LogBinner(small_Binner, capacity = 2000)
 
         @test all(ext_Binner.x_sum .== large_Binner.x_sum)
         @test all(ext_Binner.x2_sum .== large_Binner.x2_sum)
@@ -85,11 +86,12 @@
 
     xs = [rand(2, 2) for _ in 1:1000]
     small_Binner = LogBinner(zeros(2, 2), capacity = 200)
-    large_Binner = LogBinner(zeros(2, 2))
+    large_Binner = LogBinner(zeros(2, 2), capacity = 2000)
     append!(small_Binner, xs)
     append!(large_Binner, xs)
-    ext_Binner = LogBinner(small_Binner)
-    
+    @test_throws OverflowError LogBinner(small_Binner, capacity = 100)
+    ext_Binner = LogBinner(small_Binner, capacity = 2000)
+
     @test all(ext_Binner.x_sum .== large_Binner.x_sum)
     @test all(ext_Binner.x2_sum .== large_Binner.x2_sum)
     @test all(ext_Binner.count .== large_Binner.count)

--- a/test/logbinning.jl
+++ b/test/logbinning.jl
@@ -47,12 +47,13 @@
 
     # Test error on overflow
     B = LogBinner(capacity=1)
-    push!(B, 1.0)
-    @test_throws OverflowError push!(B, 2.0)
+    push!(B, 1.0); push!(B, 2.0)
+    @test !isempty(B.overflow)
+
 
     B = LogBinner(zeros(2,2), capacity=1)
-    push!(B, rand(2,2))
-    @test_throws OverflowError push!(B, rand(2,2))
+    push!(B, rand(2,2)); push!(B, rand(2,2))
+    @test !isempty(B.overflow)
 
     # time series constructor (#26)
     x = rand(10)

--- a/test/logbinning.jl
+++ b/test/logbinning.jl
@@ -66,6 +66,12 @@
     @test mean(B) == mean(x)
 
     # Test LogBinner(::LogBinner)
+    fake_Binner = LogBinner{1, String}(
+        tuple(BinningAnalysis.Compressor{String}("", false)),
+        String[], [""], [""], [0]
+    )
+    @test_throws ErrorException LogBinner(fake_Binner)
+
     for T in [Float64, ComplexF32]
         xs = rand(T, 1000)
         small_Binner = LogBinner(T, capacity = 200)

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -5,7 +5,7 @@ function performance_test(N = 28, start=1)
 
     for i in start:N
         # NOTE using the default size here actually performs better
-        BA = LogBinner(i+1)
+        BA = LogBinner(Float64, capacity = 2^i)
         xs = rand(2^i)
         GC.gc()
 
@@ -30,7 +30,7 @@ begin
     plot(xs, ys, "r+:")
     xlabel("log(Values pushed)")
     ylabel("Average time per push [ns]")
-    ylim(0, 100)
+    ylim(0, 200)
 end
 
 


### PR DESCRIPTION
In relation to #38. I thought I might as well put up a pull request, since I have the implementation of the overflow vector, `large_Binner = LogBinner(small_Binner::LogBinner)` and relevant tests are done<sup>1</sup>. I still have to check/update docstrings.

<sup>1</sup> There is no explicit test for correct overflowing, but the tests for `LogBinner(::LogBinner)` should cover it.

- [ ] Check/Update docstrings