### PR TITLE
IncrementBinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ push!(F, 2.0) # will modify x as F is just a thin wrapper
 Δx = std_error(F)
 ```
 
+### Incremental Binning
+
+```julia
+# Averages pushed values more and more, starting with no averaging
+# Averaging includes 2x more values for every blocksize averages saved
+B = IncrementBinner(0.0, blocksize=50)
+
+for x in rand(10_000)
+    push!(B, x)
+end
+
+# Returns the effective indices for the values saved
+# I.e. [1, 2, ...49, 50, 51.5, 53.5, ..., 146.5, 148.5, 151.5, ...]
+xs = indices(B)
+# Returns the averaged values saved
+ys = values(B)
+```
+
 ## Resampling methods
 
 ### Jackknife

--- a/src/BinningAnalysis.jl
+++ b/src/BinningAnalysis.jl
@@ -37,4 +37,9 @@ export means, vars, varNs, taus, std_errors
 export all_means, all_vars, all_varNs, all_taus, all_std_errors
 export covmat
 
+
+include("incrementing/IncrementBinner.jl")
+export IncrementBinner
+export indices
+
 end # module

--- a/src/incrementing/IncrementBinner.jl
+++ b/src/incrementing/IncrementBinner.jl
@@ -34,9 +34,6 @@ function IncrementBinner(x::T; blocksize = 64) where {T <: Union{Number, Abstrac
     # check keyword args
     blocksize <= 0 && throw(ArgumentError("`blocksize` must be finite and positive."))
 
-    keep = 2^ceil(Int64, log2(blocksize))
-    keep != blocksize && @info "Block size increased to $keep from $blocksize"
-
     # got_timeseries = didn't receive a zero && is a vector
     got_timeseries = count(!iszero, x) > 0 && ndims(T) == 1
 
@@ -50,7 +47,7 @@ function IncrementBinner(x::T; blocksize = 64) where {T <: Union{Number, Abstrac
         el = x
     end
 
-    B = IncrementBinner(keep, 1, 1, el, 0, S[])
+    B = IncrementBinner(blocksize, 1, 1, el, 0, S[])
 
     got_timeseries && append!(B, x)
 

--- a/src/incrementing/IncrementBinner.jl
+++ b/src/incrementing/IncrementBinner.jl
@@ -1,0 +1,98 @@
+mutable struct IncrementBinner{T}
+    keep::Int64         # number of values per block
+    compression::Int64  # current N-mean
+    stage::Int64        # stage * keep == current max length
+    
+    # for local averages
+    sum::T
+    count::Int64
+
+    output::Vector{T}
+end
+
+# Overload some basic Base functions
+Base.eltype(B::IncrementBinner{T}) where {T} = T
+Base.length(B::IncrementBinner) = length(B.output)
+Base.ndims(B::IncrementBinner{T}) where {T} = ndims(eltype(B))
+Base.isempty(B::IncrementBinner) = length(B) == 0
+
+Base.show(io::IO, B::IncrementBinner{T}) where {T} = print(io, "IncrementBinner{$T}()")
+
+"""
+    IncrementBinner([::Type{T}; blocksize = 64])
+    IncrementBinner(zero_element::T[; blocksize = 64])
+
+Creates an `IncrementBinner` from a `zero_element` numeric type `T`.
+
+Values pushed to an `IncrementBinner` are averaged in stages. For the first 
+`blocksize` values pushed no averaging happens. After that `2blocksize` elements
+are averaged 2 at a time, then `4blocksize` element 4 at a time, etc. This means 
+values pushed become progressively more compressed and smoothed.
+"""
+IncrementBinner(::Type{T} = Float64; kw...) where {T} = IncrementBinner(zero(T); kw...)
+function IncrementBinner(x::T; blocksize = 64) where {T <: Union{Number, AbstractArray}}
+    # check keyword args
+    blocksize <= 0 && throw(ArgumentError("`blocksize` must be finite and positive."))
+
+    keep = 2^ceil(Int64, log2(blocksize))
+    keep != blocksize && @info "Block size increased to $keep from $blocksize"
+
+    # got_timeseries = didn't receive a zero && is a vector
+    got_timeseries = count(!iszero, x) > 0 && ndims(T) == 1
+
+    if got_timeseries
+        # x = time series
+        S = _sum_type_heuristic(eltype(T), ndims(x[1])) # from log
+        el = zero(x[1])
+    else
+        # x = zero_element
+        S = _sum_type_heuristic(T, ndims(x))
+        el = x
+    end
+
+    B = IncrementBinner(keep, 1, 1, el, 0, S[])
+
+    got_timeseries && append!(B, x)
+
+    return B
+end
+
+function Base.push!(b::IncrementBinner{T}, x::T) where {T}
+    if b.count >= b.compression
+        push!(b.output, b.sum / b.compression)
+        b.count = 0
+        b.sum .= x
+    else
+        b.count += 1
+        b.sum .+= x
+    end
+    if length(b.output) == b.stage * b.keep
+        b.compression *= 2
+        b.stage += 1
+    end
+    nothing
+end
+
+function Base.append!(b::IncrementBinner{T}, v::Vector{T}) where {T}
+    for x in v
+        push!(b, x)
+    end
+    nothing
+end
+
+Base.values(B::IncrementBinner) = B.output
+
+function indices(B::IncrementBinner)
+    out = zeros(length(B.output))
+    step = 1
+    out[1] = 1
+    for i in 2:length(B.output)
+        if i % B.keep == 0
+            out[i] = out[i-1] + 1.5step 
+            step *= 2
+        else
+            out[i] = out[i-1] + step
+        end
+    end
+    out
+end

--- a/src/incrementing/IncrementBinner.jl
+++ b/src/incrementing/IncrementBinner.jl
@@ -58,6 +58,22 @@ function Base.push!(b::IncrementBinner{T}, x::T) where {T}
     if b.count >= b.compression
         push!(b.output, b.sum / b.compression)
         b.count = 0
+        b.sum = x
+    else
+        b.count += 1
+        b.sum += x
+    end
+    if length(b.output) == b.stage * b.keep
+        b.compression *= 2
+        b.stage += 1
+    end
+    nothing
+end
+
+function Base.push!(b::IncrementBinner{T}, x::T) where {T <: AbstractArray}
+    if b.count >= b.compression
+        push!(b.output, b.sum / b.compression)
+        b.count = 0
         b.sum .= x
     else
         b.count += 1

--- a/test/incrementbinner.jl
+++ b/test/incrementbinner.jl
@@ -6,11 +6,15 @@
     for i in 1:4
         push!(B, 1.0)
     end
-    for i in 1:8
-        push!(B, 2.0)
+    for i in 1:4
+        push!(B, 1.0)
+        push!(B, 3.0)
     end
-    for i in 1:16
+    for i in 1:4
+        push!(B, 3.0)
         push!(B, 4.0)
+        push!(B, 4.0)
+        push!(B, 5.0)
     end
 
     xs = indices(B)
@@ -28,8 +32,9 @@ end
     for i in 1:3
         push!(B, 1.0+1.0im)
     end
-    for i in 1:6
-        push!(B, 2.0+2.0im)
+    for i in 1:3
+        push!(B, 1.0+3.0im)
+        push!(B, 3.0+1.0im)
     end
 
     xs = indices(B)
@@ -47,8 +52,9 @@ end
     for i in 1:2
         push!(B, [1.0, 1.0])
     end
-    for i in 1:4
-        push!(B, [2.0, 2.0])
+    for i in 1:2
+        push!(B, [1.0, 3.0])
+        push!(B, [3.0, 1.0])
     end
 
     xs = indices(B)

--- a/test/incrementbinner.jl
+++ b/test/incrementbinner.jl
@@ -25,18 +25,18 @@ end
     
     @test B.keep == 4
 
-    for i in 1:4
+    for i in 1:3
         push!(B, 1.0+1.0im)
     end
-    for i in 1:8
+    for i in 1:6
         push!(B, 2.0+2.0im)
     end
 
     xs = indices(B)
     ys = values(B)
 
-    @test xs == Float64[1,2,3,4, 5.5,6.5,7.5,8.5]
-    @test ys == Complex64[1+1im,1+1im,1+1im,1+1im, 2+2im,2+2im,2+2im,2+2im]
+    @test xs == Float64[1,2,3, 4.5,5.5,6.5]
+    @test ys == Complex64[1+1im,1+1im,1+1im, 2+2im,2+2im,2+2im]
 end
 
 @testset "Vector" begin

--- a/test/incrementbinner.jl
+++ b/test/incrementbinner.jl
@@ -1,0 +1,59 @@
+@testset "Float64" begin
+    B = IncrementBinner(blocksize=4)
+    
+    @test B.keep == 4
+
+    for i in 1:4
+        push!(B, 1.0)
+    end
+    for i in 1:8
+        push!(B, 2.0)
+    end
+    for i in 1:16
+        push!(B, 4.0)
+    end
+
+    xs = indices(B)
+    ys = values(B)
+
+    @test xs == Float64[1,2,3,4, 5.5,6.5,7.5,8.5, 11.5,15.5,19.5,23.5]
+    @test ys == Float64[1,1,1,1, 2,2,2,2, 4,4,4,4]
+end
+
+@testset "ComplexF64" begin
+    B = IncrementBinner(ComplexF64, blocksize=3)
+    
+    @test B.keep == 4
+
+    for i in 1:4
+        push!(B, 1.0+1.0im)
+    end
+    for i in 1:8
+        push!(B, 2.0+2.0im)
+    end
+
+    xs = indices(B)
+    ys = values(B)
+
+    @test xs == Float64[1,2,3,4, 5.5,6.5,7.5,8.5]
+    @test ys == Complex64[1+1im,1+1im,1+1im,1+1im, 2+2im,2+2im,2+2im,2+2im]
+end
+
+@testset "Vector" begin
+    B = IncrementBinner([0.0, 0.0], blocksize=2)
+    
+    @test B.keep == 2
+
+    for i in 1:2
+        push!(B, [1.0, 1.0])
+    end
+    for i in 1:4
+        push!(B, [2.0, 2.0])
+    end
+
+    xs = indices(B)
+    ys = values(B)
+
+    @test xs == Float64[1,2, 3.5,5.5]
+    @test ys == [[1.0, 1.0], [1.0, 1.0], [2.0, 2.0], [2.0, 2.0]]
+end


### PR DESCRIPTION
I want something better to deal with recording observables during thermalization in https://github.com/crstnbr/MonteCarlo.jl. 

The interesting property in that case is how long it takes for an observable to converge. For that we want high data resolution at the start, but decreasing over time as to not have an overwhelming amount of data. 

The idea of an `IncrementBinner` is to provide such a compression. The first `blocksize` values pushed are added as-is. Then, the next `2blocksize` values are averaged in pairs resulting in another `blocksize` saved values. After that it's `4blocksize` values compressed with 4-means, `8blocksize` with 8-means, etc. The amount of storage used ends up as `O(blocksize * log2(N))` where `N` is the number of values pushed.